### PR TITLE
Fixes a compilation error for wasm targets.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1"
 sha3 = "0.9"
 strum_macros = "0.21"
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.3", features = ["js"]}
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha3 = "0.9"
 strum_macros = "0.21"
+getrandom = { version = "0.2.3", features = ["js"]}
 
 [dev-dependencies]
 evmodin-test = { path = ".", package = "evmodin", features = ["util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha3 = "0.9"
 strum_macros = "0.21"
+
+[target.'cfg(target_arch = "x86_64")'.dependencies]
 getrandom = { version = "0.2.3", features = ["js"]}
 
 [dev-dependencies]


### PR DESCRIPTION
Without this fix, the build fails when targetting wasm. Repro steps:

```
$ wasm-pack build --target web
[INFO]: 🎯  Checking for the Wasm target...
[INFO]: 🌀  Compiling to Wasm...
   Compiling getrandom v0.2.3
error: the wasm32-unknown-unknown target is not supported by default, you may need to enable the "js" feature. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> /*******/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.3/src/lib.rs:219:9
    |
219 | /         compile_error!("the wasm32-unknown-unknown target is not supported by \
220 | |                         default, you may need to enable the \"js\" feature. \
221 | |                         For more information see: \
222 | |                         https://docs.rs/getrandom/#webassembly-support");
    | |_________________________________________________________________________^

error[E0433]: failed to resolve: use of undeclared crate or module `imp`
   --> /********/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.2.3/src/lib.rs:246:5
    |
246 |     imp::getrandom_inner(dest)
    |     ^^^ use of undeclared crate or module `imp`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `getrandom` due to 2 previous errors
Error: Compiling your crate to WebAssembly failed
Caused by: failed to execute `cargo build`: exited with exit status: 101
  full command: "cargo" "build" "--lib" "--release" "--target" "wasm32-unknown-unknown"
```

After applying this fix the compilation succeeds:

```
$ wasm-pack build --target web
[INFO]: 🎯  Checking for the Wasm target...
[INFO]: 🌀  Compiling to Wasm...
    Finished release [optimized] target(s) in 0.13s
[INFO]: ⬇️  Installing wasm-bindgen...
[INFO]: Optimizing wasm binaries with `wasm-opt`...
[INFO]: Optional fields missing from Cargo.toml: 'description', 'repository'. These are not necessary, but recommended
[INFO]: ✨   Done in 0.71s
[INFO]: 📦   Your wasm pkg is ready to publish at /*****/evmodin/pkg.
```